### PR TITLE
CODA-129 - Fallback for missing configCat key

### DIFF
--- a/utils/featureflags.go
+++ b/utils/featureflags.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"errors"
 	"gopkg.in/configcat/go-sdk.v1"
 	"os"
 )
@@ -9,19 +10,22 @@ var (
 	client *configcat.Client
 )
 
-func getClient() *configcat.Client {
+func getClient() (*configcat.Client, error) {
 	if client == nil {
 		client = configcat.NewClient(os.Getenv("WEBAPP_CONFIGCAT_KEY"))
+		return client, nil
 	}
-	return client
+	return client, errors.New("no configCat client")
 }
 
 // GetFeatureFlag - gets feature flag
 func GetFeatureFlag(name string, defaultValue bool) (bool, bool) {
-	if IsTestEnv() {
+	client, err := getClient()
+	value, ok := client.GetValue(name, defaultValue).(bool)
+
+	if IsTestEnv() || !ok || err != nil {
 		return true, true
 	}
 
-	value, ok := getClient().GetValue(name, defaultValue).(bool)
 	return value, ok
 }

--- a/utils/featureflags.go
+++ b/utils/featureflags.go
@@ -5,17 +5,17 @@ import (
 	"os"
 )
 
-type IClient interface {
+type iClient interface {
 	GetValue(string, interface{}) interface{}
 }
 
 var (
 	newClient = configcat.NewClient
-	client    IClient
+	client    iClient
 	apiKey    = os.Getenv("WEBAPP_CONFIGCAT_KEY")
 )
 
-func getClient() IClient {
+func getClient() iClient {
 	if client == nil && apiKey != "" {
 		client = newClient(apiKey)
 		return client

--- a/utils/featureflags_test.go
+++ b/utils/featureflags_test.go
@@ -1,0 +1,71 @@
+package utils
+
+import (
+	"gopkg.in/configcat/go-sdk.v1"
+	"testing"
+)
+
+type ClientMock struct{}
+
+func (c ClientMock) GetValue(key string, defaultValue interface{}) interface{} {
+	if key == "key-false" {
+		return false
+	}
+	if key == "key-true" {
+		return true
+	}
+	return defaultValue
+}
+
+func TestGetFeatureFlag(t *testing.T) {
+	t.Run("When `Client` is defined", func(t *testing.T) {
+		t.Run("Should return `true` for flags that are set for `true`", func(t *testing.T) {
+			client = ClientMock{}
+			apiKey = "34jdu4f8uh4hu8"
+
+			value, ok := GetFeatureFlag("key-true", false)
+
+			if !ok || value == false {
+				t.Errorf("Returned `false` for flag that is set for `true`")
+			}
+		})
+
+		t.Run("Should return `false` for flags that are set for `false`", func(t *testing.T) {
+			client = ClientMock{}
+			apiKey = "34jdu4f8uh4hu8"
+
+			value, ok := GetFeatureFlag("key-false", true)
+
+			if !ok || value == true {
+				t.Errorf("Returned `true` for flag that is set for `false`")
+			}
+		})
+
+		t.Run("Should return default value for flag that doesn't have assigned value", func(t *testing.T) {
+			client = ClientMock{}
+			apiKey = "34jdu4f8uh4hu8"
+
+			value, ok := GetFeatureFlag("key-unknown", true)
+
+			if ok == false || value == false {
+				t.Errorf("Returned not default value")
+			}
+		})
+	})
+
+	t.Run("When `Client` is not defined", func(t *testing.T) {
+		t.Run("Should return `true` for any flag when client is not defined", func(t *testing.T) {
+			client = nil
+			apiKey = ""
+			newClient = func(apiKey string) *configcat.Client {
+				return nil
+			}
+
+			value, ok := GetFeatureFlag("key-true", false)
+
+			if !ok || value == false {
+				t.Errorf("Returned `false` when for not defined Client all flags should be `true`")
+			}
+		})
+	})
+}


### PR DESCRIPTION
**Business justification:** https://trello.com/c/R8xFkaFf/129-coda-129-fallback-for-missing-configcat-key

**Description:** For development purposes, when configCat key is not present, enable all features hidden behind feature flag.