### PR TITLE
CODA-165 - Landing page

### DIFF
--- a/controllers/api/platform/constants.go
+++ b/controllers/api/platform/constants.go
@@ -1,0 +1,5 @@
+package platform
+
+var (
+	href = "/api/platform"
+)

--- a/controllers/api/platform/controller.go
+++ b/controllers/api/platform/controller.go
@@ -1,0 +1,20 @@
+package platform
+
+import (
+	"github.com/coda-it/gowebapp/controllers/base"
+	platformUsecases "github.com/coda-it/gowebapp/domain/usecases/platform"
+)
+
+// Controller - platform controller
+type Controller struct {
+	*base.Controller
+	PlatformUsecases platformUsecases.Usecase
+}
+
+// New - creates new instance of platform database controller
+func New(b *base.Controller, pu platformUsecases.Usecase) *Controller {
+	return &Controller{
+		b,
+		pu,
+	}
+}

--- a/controllers/api/platform/get.go
+++ b/controllers/api/platform/get.go
@@ -1,0 +1,34 @@
+package platform
+
+import (
+	"github.com/coda-it/gowebserver/router"
+	"github.com/coda-it/gowebserver/session"
+	"github.com/coda-it/gowebserver/store"
+	"net/http"
+)
+
+// CtrPlatformGet - gets platform config
+func (c *Controller) CtrPlatformGet(w http.ResponseWriter, r *http.Request, opt router.URLOptions, sm session.ISessionManager, s store.IStore) {
+	config, err := c.PlatformUsecases.Fetch()
+	var data map[string]interface{}
+
+	if err != nil {
+		data = map[string]interface{}{
+			"config": struct{}{},
+		}
+	}
+
+	data = map[string]interface{}{
+		"config": config,
+	}
+
+	links := map[string]map[string]string{
+		"self": map[string]string{
+			"href": href,
+		},
+	}
+
+	embedded := map[string]interface{}{}
+
+	c.HandleJSONResponse(w, data, embedded, links, http.StatusOK)
+}

--- a/controllers/api/platform/post.go
+++ b/controllers/api/platform/post.go
@@ -1,0 +1,37 @@
+package platform
+
+import (
+	"encoding/json"
+	"github.com/coda-it/gowebapp/domain/models/platform"
+	"github.com/coda-it/gowebserver/router"
+	"github.com/coda-it/gowebserver/session"
+	"github.com/coda-it/gowebserver/store"
+	"io/ioutil"
+	"net/http"
+)
+
+const platformHref string = "/api/platform"
+
+// CtrPlatformPost - insert platform info
+func (c *Controller) CtrPlatformPost(w http.ResponseWriter, r *http.Request, opt router.URLOptions, sm session.ISessionManager, s store.IStore) {
+	requestBody, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		c.HandleErrorResponse(w, "error reading request body")
+		return
+	}
+	defer r.Body.Close()
+
+	var newConfig platform.Config
+
+	err = json.Unmarshal(requestBody, &newConfig)
+	if err != nil {
+		c.HandleErrorResponse(w, err.Error())
+		return
+	}
+
+	err = c.PlatformUsecases.Add(newConfig)
+
+	if err != nil {
+		c.HandleErrorResponse(w, "error adding new platfrom config")
+	}
+}

--- a/controllers/api/platform/put.go
+++ b/controllers/api/platform/put.go
@@ -1,0 +1,51 @@
+package platform
+
+import (
+	"encoding/json"
+	"github.com/coda-it/gowebapp/domain/models/platform"
+	"github.com/coda-it/gowebserver/router"
+	"github.com/coda-it/gowebserver/session"
+	"github.com/coda-it/gowebserver/store"
+	"io/ioutil"
+	"net/http"
+)
+
+// CtrPlatformPut - update post
+func (c *Controller) CtrPlatformPut(w http.ResponseWriter, r *http.Request, opt router.URLOptions, sm session.ISessionManager, s store.IStore) {
+	requestBody, err := ioutil.ReadAll(r.Body)
+
+	if err != nil {
+		c.HandleErrorResponse(w, "error reading request body")
+		return
+	}
+	defer r.Body.Close()
+
+	var editedConfig platform.Config
+	err = json.Unmarshal(requestBody, &editedConfig)
+	if err != nil {
+		c.HandleErrorResponse(w, err.Error())
+		return
+	}
+
+	err = c.PlatformUsecases.Update(editedConfig)
+
+	if err != nil {
+		c.HandleErrorResponse(w, "error updating platform config")
+	}
+
+	data := struct {
+		Config platform.Config `json:"config"`
+	}{
+		editedConfig,
+	}
+
+	links := map[string]map[string]string{
+		"self": map[string]string{
+			"href": href,
+		},
+	}
+
+	embedded := map[string]string{}
+
+	c.HandleJSONResponse(w, data, embedded, links, http.StatusOK)
+}

--- a/data/repositories/platform/platfrom.go
+++ b/data/repositories/platform/platfrom.go
@@ -28,21 +28,21 @@ func (r *Repository) Drop() error {
 }
 
 // Add - inserts platform config
-func (cr *Repository) Add(c platformModel.Config) error {
-	platformCollection := cr.Persistence.GetCollection(collectionName)
+func (r *Repository) Add(c platformModel.Config) error {
+	platformCollection := r.Persistence.GetCollection(collectionName)
 	return platformCollection.Insert(c)
 }
 
 // Update - update platform config
-func (cr *Repository) Update(c platformModel.Config) error {
-	platformCollection := cr.Persistence.GetCollection(collectionName)
+func (r *Repository) Update(c platformModel.Config) error {
+	platformCollection := r.Persistence.GetCollection(collectionName)
 	_, err := platformCollection.Upsert(bson.M{"_id": c.ID}, c)
 	return err
 }
 
 // Fetch - fetch platform config
-func (cr *Repository) Fetch() (platformModel.Config, error) {
-	platformCollection := cr.Persistence.GetCollection(collectionName)
+func (r *Repository) Fetch() (platformModel.Config, error) {
+	platformCollection := r.Persistence.GetCollection(collectionName)
 
 	var config platformModel.Config
 	var searchQuery bson.M

--- a/data/repositories/platform/platfrom.go
+++ b/data/repositories/platform/platfrom.go
@@ -1,6 +1,14 @@
 package platform
 
-import "github.com/coda-it/gowebapp/data/persistence"
+import (
+	"github.com/coda-it/gowebapp/data/persistence"
+	platformModel "github.com/coda-it/gowebapp/domain/models/platform"
+	"gopkg.in/mgo.v2/bson"
+)
+
+const (
+	collectionName = "platform"
+)
 
 // Repository - platform repository
 type Repository struct {
@@ -17,4 +25,33 @@ func New(p persistence.IPersistance) *Repository {
 // Drop - drops whole database
 func (r *Repository) Drop() error {
 	return r.Persistence.DropDatabase()
+}
+
+// Add - inserts platform config
+func (cr *Repository) Add(c platformModel.Config) error {
+	platformCollection := cr.Persistence.GetCollection(collectionName)
+	return platformCollection.Insert(c)
+}
+
+// Update - update platform config
+func (cr *Repository) Update(c platformModel.Config) error {
+	platformCollection := cr.Persistence.GetCollection(collectionName)
+	_, err := platformCollection.Upsert(bson.M{"_id": c.ID}, c)
+	return err
+}
+
+// Fetch - fetch platform config
+func (cr *Repository) Fetch() (platformModel.Config, error) {
+	platformCollection := cr.Persistence.GetCollection(collectionName)
+
+	var config platformModel.Config
+	var searchQuery bson.M
+
+	err := platformCollection.Find(searchQuery).One(&config)
+
+	if err != nil {
+		return config, err
+	}
+
+	return config, nil
 }

--- a/domain/models/platform/config.go
+++ b/domain/models/platform/config.go
@@ -1,0 +1,11 @@
+package platform
+
+import (
+	"gopkg.in/mgo.v2/bson"
+)
+
+// Config - model representing platform config
+type Config struct {
+	ID            bson.ObjectId `json:"id" bson:"_id,omitempty"`
+	LandingModule string        `json:"landingModule" bson:"landingModule"`
+}

--- a/domain/usecases/platform/interfaces.go
+++ b/domain/usecases/platform/interfaces.go
@@ -1,6 +1,13 @@
 package platform
 
+import (
+	platformModel "github.com/coda-it/gowebapp/domain/models/platform"
+)
+
 // IRepository - platform repository interface
 type IRepository interface {
 	Drop() error
+	Add(c platformModel.Config) error
+	Update(c platformModel.Config) error
+	Fetch() (platformModel.Config, error)
 }

--- a/domain/usecases/platform/platform.go
+++ b/domain/usecases/platform/platform.go
@@ -1,5 +1,9 @@
 package platform
 
+import (
+	platformModel "github.com/coda-it/gowebapp/domain/models/platform"
+)
+
 // Usecase - platform usecases
 type Usecase struct {
 	repository IRepository
@@ -15,4 +19,19 @@ func New(r IRepository) *Usecase {
 // Drop - drops database
 func (u *Usecase) Drop() error {
 	return u.repository.Drop()
+}
+
+// Fetch - fetch platform config
+func (u *Usecase) Fetch() (platformModel.Config, error) {
+	return u.repository.Fetch()
+}
+
+// Add - add platform config
+func (u *Usecase) Add(c platformModel.Config) error {
+	return u.repository.Add(c)
+}
+
+// Update - update platform config
+func (u *Usecase) Update(c platformModel.Config) error {
+	return u.repository.Update(c)
 }

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	adminController "github.com/coda-it/gowebapp/controllers/admin"
 	categoryApiController "github.com/coda-it/gowebapp/controllers/api/category"
 	loginApiController "github.com/coda-it/gowebapp/controllers/api/login"
+	"github.com/coda-it/gowebapp/controllers/api/platform"
 	postApiController "github.com/coda-it/gowebapp/controllers/api/post"
 	"github.com/coda-it/gowebapp/controllers/api/reset"
 	"github.com/coda-it/gowebapp/controllers/api/user"
@@ -319,6 +320,7 @@ func main() {
 	}
 
 	resetCtl := reset.New(baseController, *platformUsecasesEntity)
+	platformCtl := platform.New(baseController, *platformUsecasesEntity)
 	platformModule := module.Module{
 		Enabled: true,
 		Routes: []route.Route{
@@ -327,6 +329,24 @@ func main() {
 				Method:    "ALL",
 				Handler:   resetCtl.CtrResetDb,
 				Protected: false,
+			},
+			{
+				Path:      "/api/platform",
+				Method:    "GET",
+				Handler:   platformCtl.CtrPlatformGet,
+				Protected: true,
+			},
+			{
+				Path:      "/api/platform",
+				Method:    "POST",
+				Handler:   platformCtl.CtrPlatformPost,
+				Protected: true,
+			},
+			{
+				Path:      "/api/platform",
+				Method:    "PUT",
+				Handler:   platformCtl.CtrPlatformPut,
+				Protected: true,
 			},
 		},
 	}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "noImplicitAny": false,
     "removeComments": true,
     "preserveConstEnums": true,
-    "sourceMap": true,
+    "sourceMap": false,
+    "noEmit": true,
     "jsx": "react",
     "baseUrl": "./"
   }


### PR DESCRIPTION
**Business justification:** https://trello.com/c/tXnH6QsE/165-coda-165-landing-page

**Description:** Add `/api/platform` endpoint that will create (POST), update (PUT) and read (GET) platform config. When no config exists in the data base an empty config is served. For now the endpoint just persists config (it doesn't affect the platform in any way).

Config structure: 
```
{
 id: string,
 landingModule: string,
}
```

How to test endpoint:

**POST:** (when posting, config ID is created, for not for POST no response is given - when no error occurs it means config has been created - in order to fetch it, you'll need to use GET)
```
curl --header “Content-Type: application/json” \
  --request POST \
  --data ‘{“landingModule”: “module-1”}’ \
  http://localhost:3000/api/platform
```

**PUT:**
```
curl --header “Content-Type: application/json” \
  --request PUT \
  --data ‘{“id”: “607727df04035c1573ff4f0a”, “landingModule”: “module-2”}’ \
  http://localhost:3000/api/platform
```

As an addition a bug with generating a bunch of js and map.js files is fixed.