### PR TITLE
CODA-187 - Binary release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,5 +49,4 @@ deploy:
     - "public/*"
   skip_cleanup: true
   on:
-    branch: master
     condition: $TRAVIS_COMMIT_MESSAGE =~ ^Build.*


### PR DESCRIPTION
**Business justification:** https://trello.com/c/xiQ84Zub/187-coda-187-binary-release

**Description:** Apparently for `provider: releases` tags and branch cannot be used simultaneously, as tags are present only on master branch, I'm removing `branch` property.