### PR TITLE
CODA-281 - Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,10 +85,10 @@ version:
 	$(NPM) version $(V) --no-git-tag-version
 	git add package.json
 	git add package-lock.json
-	sed -i "" "s/APP_VERSION:.*/APP_VERSION: $(V)/g" ./github/workflows/test.yml
-	git add ./github/workflows/test.yml
-	sed -i "" "s/APP_VERSION:.*/APP_VERSION: $(V)/g" ./github/workflows/build.yml
-	git add ./github/workflows/build.yml
+	sed -i "" "s/APP_VERSION:.*/APP_VERSION: $(V)/g" .github/workflows/test.yml
+	git add .github/workflows/test.yml
+	sed -i "" "s/APP_VERSION:.*/APP_VERSION: $(V)/g" .github/workflows/build.yml
+	git add .github/workflows/build.yml
 	git add ./version.go || true
 	git add ./docs/changelogs/CHANGELOG_$(V).md
 	git commit --allow-empty -m "Build $(V)"


### PR DESCRIPTION
**Business justification:** https://trello.com/c/n0vQoH5V/281-coda-fix-makefile

**Description:** Since migration from TravcisCI to GH Actions a Makefile has been broken.