### PR TITLE
CODA-291 - Static page don't respect domain for its application

### DIFF
--- a/controllers/base/controller.go
+++ b/controllers/base/controller.go
@@ -179,9 +179,11 @@ func (c *Controller) RenderStaticTemplate(
 	appPath := constants.DefaultAppID + "/"
 
 	for _, app := range c.Config.Apps {
-		for _, module := range app.Modules {
-			if module.ID == constants.StaticModule {
-				appPath = app.ID + "/"
+		if app.Domain == "" || r.Host == app.Domain {
+			for _, module := range app.Modules {
+				if module.ID == constants.StaticModule {
+					appPath = app.ID + "/"
+				}
 			}
 		}
 	}


### PR DESCRIPTION
**Business justification:** https://trello.com/c/t14VlOb9/291-coda-291-static-page-dont-respect-domain-for-its-application

**Description:** Static app should respect domain for its application.